### PR TITLE
Use accounts from the database

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,4 +29,7 @@ go run "$BASEDIR/migrate.go"
 echo "Prepopulating decks"
 "$BASEDIR/scripts/create_basic_decks.py" "$DBFILE"
 
+echo "Creating default user"
+"$BASEDIR/scripts/create_default_user.py" "$DBFILE"
+
 echo "Done."

--- a/scripts/create_default_user.py
+++ b/scripts/create_default_user.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+"""
+Create the default user and achievement tracking
+"""
+import sqlite3
+import sys
+from datetime import datetime
+
+
+def main():
+	if len(sys.argv) < 2:
+		sys.stderr.write("USAGE: %s [dbfile]\n" % (sys.argv[0]))
+		exit(1)
+	dbfile = sys.argv[1]
+
+	connection = sqlite3.connect(dbfile)
+	cursor = connection.cursor()
+
+	bnet_id = None
+	updated_at = datetime.now()
+	flags = None
+
+	cursor.execute("INSERT INTO account VALUES (?, ?, ?, ?)", (
+		None,
+		bnet_id,
+		updated_at,
+		flags
+	))
+
+	account_id = cursor.lastrowid
+
+	connection.commit()
+	connection.close()
+
+
+if __name__ == "__main__":
+	main()


### PR DESCRIPTION
A bootstrap script creates the default user which is then used for access to decks and boosters. 
Preconstructed decks are shared by all accounts and have no owner.
Access to decks not owned by the account (including precon decks) emit a warning and return early, although precon decks can be read by any account.

The deck access restrictions may need a little modification for brawls, arena and AI decks.