### PR TITLE
Tracked achievement progress

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -17,6 +17,7 @@ func main() {
 	conn.AutoMigrate(
 		&pegasus.Account{},
 		&pegasus.AccountLicense{},
+		&pegasus.Achieve{},
 		&pegasus.Booster{},
 		&pegasus.BoosterCard{},
 		&pegasus.Deck{},

--- a/pegasus/account.go
+++ b/pegasus/account.go
@@ -37,6 +37,7 @@ func (v *Account) Init(sess *Session) {
 	sess.RegisterUtilHandler(0, 253, OnGetAchieves)
 	sess.RegisterUtilHandler(0, 267, OnCheckAccountLicenses)
 	sess.RegisterUtilHandler(1, 276, OnCheckGameLicenses)
+	sess.RegisterUtilHandler(0, 281, OnCancelQuest)
 	sess.RegisterUtilHandler(0, 284, OnValidateAchieve)
 	sess.RegisterUtilHandler(0, 291, OnSetCardBack)
 	sess.RegisterUtilHandler(0, 305, OnGetAdventureProgress)
@@ -350,6 +351,27 @@ func OnValidateAchieve(s *Session, body []byte) ([]byte, error) {
 	res := hsproto.PegasusUtil_ValidateAchieveResponse{}
 	res.Achieve = proto.Int32(req.GetAchieve())
 	return EncodeUtilResponse(285, &res)
+}
+
+func OnCancelQuest(s *Session, body []byte) ([]byte, error) {
+	req := hsproto.PegasusUtil_CancelQuest{}
+	err := proto.Unmarshal(body, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: check if the quest is a daily that can be canceled and if so cancel it.
+	// Note that if CancelQuestResponse.Success is true the client will request
+	//  a new set of achieves and expect a new daily
+	log.Printf("TODO: OnCancelQuest stub = %s", req.String())
+
+	res := hsproto.PegasusUtil_CancelQuestResponse {
+		QuestId:         proto.Int32(req.GetQuestId()),
+		Success:         proto.Bool(true),
+		NextQuestCancel: PegasusDate(time.Now().UTC()),
+	}
+
+	return EncodeUtilResponse(282, &res)
 }
 
 func MakeDeckInfo(deck *Deck) *hsproto.PegasusShared_DeckInfo {

--- a/pegasus/account.go
+++ b/pegasus/account.go
@@ -33,6 +33,7 @@ func (v *Account) Init(sess *Session) {
 	sess.RegisterUtilHandler(0, 225, OnOpenBooster)
 	sess.RegisterUtilHandler(0, 239, OnSetOptions)
 	sess.RegisterUtilHandler(0, 240, OnGetOptions)
+	sess.RegisterUtilHandler(0, 243, OnAckAchieveProgress)
 	sess.RegisterUtilHandler(0, 253, OnGetAchieves)
 	sess.RegisterUtilHandler(0, 267, OnCheckAccountLicenses)
 	sess.RegisterUtilHandler(1, 276, OnCheckGameLicenses)
@@ -322,6 +323,21 @@ func OnGetAchieves(s *Session, body []byte) ([]byte, error) {
 		})
 	}
 	return EncodeUtilResponse(252, &res)
+}
+
+func OnAckAchieveProgress(s *Session, body []byte) ([]byte, error) {
+	req := hsproto.PegasusUtil_AckAchieveProgress{}
+	err := proto.Unmarshal(body, &req)
+	if err != nil {
+		return nil, err
+	}
+
+	achieve := Achieve{}
+	db.Where("achieve_id = ? and account_id = ?", req.Id, s.Account.ID).First(&achieve)
+	achieve.AckProgress = req.GetAckProgress()
+	db.Save(&achieve)
+
+	return nil, nil
 }
 
 func OnValidateAchieve(s *Session, body []byte) ([]byte, error) {

--- a/pegasus/account.go
+++ b/pegasus/account.go
@@ -308,14 +308,18 @@ func OnGetAchieves(s *Session, body []byte) ([]byte, error) {
 	dbfAchieves := []DbfAchieve{}
 	db.Find(&dbfAchieves)
 	for _, achieve := range dbfAchieves {
-		info := &hsproto.PegasusUtil_Achieve{}
-		info.Id = proto.Int32(int32(achieve.ID))
-		info.Progress = proto.Int32(1)
-		info.AckProgress = proto.Int32(1)
-		info.CompletionCount = proto.Int32(1)
-		info.StartedCount = proto.Int32(1)
-		info.DateGiven = PegasusDate(time.Now())
-		res.List = append(res.List, info)
+		achieveProgress := Achieve{}
+		db.Where("achieve_id = ? and account_id = ?", achieve.ID, s.Account.ID).First(&achieveProgress)
+
+		res.List = append(res.List, &hsproto.PegasusUtil_Achieve{
+			Id:               proto.Int32(achieve.ID),
+			Progress:         proto.Int32(achieveProgress.Progress),
+			AckProgress:      proto.Int32(achieveProgress.AckProgress),
+			CompletionCount:  proto.Int32(achieveProgress.CompletionCount),
+			Active:           proto.Bool(achieveProgress.Active),
+			DateGiven:        PegasusDate(achieveProgress.DateGiven),
+			DateCompleted:    PegasusDate(achieveProgress.DateCompleted),
+		})
 	}
 	return EncodeUtilResponse(252, &res)
 }

--- a/pegasus/db.go
+++ b/pegasus/db.go
@@ -18,6 +18,21 @@ func openDB() gorm.DB {
 	return db
 }
 
+type Achieve struct {
+	ID               int32
+	AccountID        int64
+	AchieveID        int32
+
+	Progress         int32
+	AckProgress      int32
+	CompletionCount  int32
+	Active           bool
+	// started_count doesn't seem to be used
+	DateGiven        time.Time
+	DateCompleted    time.Time
+	// do_not_ack is also not used
+}
+
 type Booster struct {
 	ID          int64
 	AccountID   int64

--- a/scripts/create_default_user.py
+++ b/scripts/create_default_user.py
@@ -17,7 +17,8 @@ def main():
 	cursor = connection.cursor()
 
 	bnet_id = None
-	updated_at = datetime.now()
+	now = datetime.now()
+	updated_at = now
 	flags = None
 
 	cursor.execute("INSERT INTO account VALUES (?, ?, ?, ?)", (
@@ -26,8 +27,33 @@ def main():
 		updated_at,
 		flags
 	))
-
 	account_id = cursor.lastrowid
+	assert account_id
+
+	achieves = []
+	for dbf_achieve in cursor.execute("SELECT * FROM dbf_achieve"):
+		id = None
+		achieve_id = dbf_achieve[0]
+		progress = 1
+		ack_progress = 1
+		completion_count = 1
+		active = False
+		date_given = now
+		date_completed = now
+
+		achieves.append((
+			id,
+			account_id,
+			achieve_id,
+			progress,
+			ack_progress,
+			completion_count,
+			active,
+			date_given,
+			date_completed
+		))
+
+	connection.executemany("INSERT INTO achieve VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", achieves)
 
 	connection.commit()
 	connection.close()


### PR DESCRIPTION
Achievements for the default user are created by `create_default_user.py`.
These achievements are used for tracking progress of the account's achievements when the client calls `GetAchieves`. 

Acknowledgment of achievement progress is also implemented and a stub for OnCancelQuest has been added for when dailies are implemented.