### PR TITLE
Implement notification channel

### DIFF
--- a/bnet/auth.go
+++ b/bnet/auth.go
@@ -133,7 +133,8 @@ func (s *AuthServerService) CompleteLogin() error {
 		res.ConnectedRegion = proto.Uint32(0x5553) // 'US'
 
 		if s.program == "WTCG" {
-			s.sess.game = s.sess.server.ConnectGameServer(s.sess, s.program)
+			s.sess.server.ConnectGameServer(s.sess, s.program)
+			go s.sess.HandleNotifications()
 		}
 		s.sess.startedPlaying = time.Now()
 	}

--- a/bnet/game_master.go
+++ b/bnet/game_master.go
@@ -1,0 +1,149 @@
+package bnet
+
+import (
+	"fmt"
+	"github.com/HearthSim/hs-proto-go/bnet/game_master_service"
+	"github.com/golang/protobuf/proto"
+	"log"
+)
+
+type GameMasterServiceBinder struct{}
+
+func (GameMasterServiceBinder) Bind(sess *Session) Service {
+	res := &GameMasterService{}
+	res.sess = sess
+	return res
+}
+
+// The GameUtilities service arbitrates packets between the client and servers
+// specific to individual games.
+type GameMasterService struct {
+	sess *Session
+}
+
+func (s *GameMasterService) Name() string {
+	return "bnet.protocol.game_master.GameMaster"
+}
+
+func (s *GameMasterService) Methods() []string {
+	return []string{
+		"",
+		"JoinGame",
+		"ListFactories",
+		"FindGame",
+		"CancelGameEntry",
+		"GameEnded",
+		"PlayerLeft",
+		"RegisterServer",
+		"UnregisterServer",
+		"RegisterUtilities",
+		"UnregisterUtilities",
+		"Subscribe",
+		"Unsubscribe",
+		"ChangeGame",
+		"GetFactoryInfo",
+		"GetGameStats",
+	}
+}
+
+func (s *GameMasterService) Invoke(method int, body []byte) (resp []byte, err error) {
+	switch method {
+	case 1:
+		return s.JoinGame(body)
+	case 2:
+		return s.ListFactories(body)
+	case 3:
+		return s.FindGame(body)
+	case 4:
+		return []byte{}, s.CancelGameEntry(body)
+	case 5:
+		return nil, s.GameEnded(body)
+	case 6:
+		return []byte{}, s.PlayerLeft(body)
+	case 7:
+		return []byte{}, s.RegisterServer(body)
+	case 8:
+		return nil, s.UnregisterServer(body)
+	case 9:
+		return []byte{}, s.RegisterUtilities(body)
+	case 10:
+		return nil, s.UnregisterUtilities(body)
+	case 11:
+		return s.Subscribe(body)
+	case 12:
+		return nil, s.Unsubscribe(body)
+	case 13:
+		return []byte{}, s.ChangeGame(body)
+	case 14:
+		return s.GetFactoryInfo(body)
+	case 15:
+		return s.GetGameStats(body)
+	default:
+		log.Panicf("error: GameMasterService.Invoke: unknown method %v", method)
+		return
+	}
+}
+
+func (s *GameMasterService) JoinGame(body []byte) ([]byte, error) {
+	return nil, nyi
+}
+
+func (s *GameMasterService) ListFactories(body []byte) ([]byte, error) {
+	return nil, nyi
+}
+
+func (s *GameMasterService) FindGame(body []byte) ([]byte, error) {
+	req := &game_master_service.FindGameRequest{}
+	proto.Unmarshal(body, req)
+	fmt.Println(req.String())
+	// TODO: send notification to game server
+	return nil, nyi
+}
+
+func (s *GameMasterService) CancelGameEntry(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) GameEnded(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) PlayerLeft(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) RegisterServer(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) UnregisterServer(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) RegisterUtilities(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) UnregisterUtilities(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) Subscribe(body []byte) ([]byte, error) {
+	return nil, nyi
+}
+
+func (s *GameMasterService) Unsubscribe(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) ChangeGame(body []byte) error {
+	return nyi
+}
+
+func (s *GameMasterService) GetFactoryInfo(body []byte) ([]byte, error) {
+	return nil, nyi
+}
+
+func (s *GameMasterService) GetGameStats(body []byte) ([]byte, error) {
+	return nil, nyi
+}

--- a/bnet/notification.go
+++ b/bnet/notification.go
@@ -1,0 +1,158 @@
+package bnet
+
+import (
+	"github.com/HearthSim/hs-proto-go/bnet/attribute"
+	"github.com/HearthSim/hs-proto-go/bnet/entity"
+	"github.com/golang/protobuf/proto"
+	"log"
+)
+
+const (
+	NotifyClientRequest    = "GS_CL_REQ"
+	NotifyClientResponse   = "GS_CL_RES"
+	NotifyFindGameRequest  = "GS_FG_REQ"
+	NotifyFindGameResponse = "GS_FG_RES"
+	NotifyQueueEntry       = "GQ_ENTRY"
+	NotifyQueueUpdate      = "GQ_UPDATE"
+	NotifyQueueExit        = "GQ_EXIT"
+	NotifyQueueResult      = "G_RESULT"
+	NotifyMatchMakerStart  = "MM_START"
+	NotifyMatchMakerEnd    = "MM_END"
+	NotifyWhisper          = "WHISPER"
+	NotifySpectatorInvite  = "WTCG.SpectatorInvite"
+)
+
+// A notification sent or received by battle.net from or to another server.
+type Notification struct {
+	Type       string
+	Attributes []*attribute.Attribute
+}
+
+// Wrapper type for disambiguationg blob and message values in attributes.
+type MessageValue struct {
+	Value []byte
+}
+
+// Wrapper type for disambiguationg string and fourcc values in attributes.
+type FourccValue struct {
+	Value string
+}
+
+func NewNotification(ty string, m map[string]interface{}) *Notification {
+	res := &Notification{}
+	res.Type = ty
+	for k, v := range m {
+		variant := &attribute.Variant{}
+		switch v := v.(type) {
+		case bool:
+			variant.BoolValue = proto.Bool(v)
+		// Minor annoyance here to have to do these casts, but it would be
+		// a huge annoyance elsewhere:
+		case int:
+			variant.IntValue = proto.Int64(int64(v))
+		case int32:
+			variant.IntValue = proto.Int64(int64(v))
+		case int64:
+			variant.IntValue = proto.Int64(v)
+		case uint:
+			variant.UintValue = proto.Uint64(uint64(v))
+		case uint32:
+			variant.UintValue = proto.Uint64(uint64(v))
+		case uint64:
+			variant.UintValue = proto.Uint64(v)
+		case float32:
+			variant.FloatValue = proto.Float64(float64(v))
+		case float64:
+			variant.FloatValue = proto.Float64(v)
+		case string:
+			variant.StringValue = proto.String(v)
+		case []byte:
+			variant.BlobValue = v
+		case MessageValue:
+			variant.MessageValue = v.Value
+		case FourccValue:
+			variant.FourccValue = proto.String(v.Value)
+		case entity.EntityId:
+			variant.EntityidValue = &v
+		default:
+			log.Panicf("error: can't convert %s: %T to attribute", k, v)
+		}
+		res.Attributes = append(res.Attributes, &attribute.Attribute{
+			Name:  proto.String(k),
+			Value: variant,
+		})
+	}
+	return res
+}
+
+// Converts a notification into a flat map containing a type key for the
+// notification's type and all of the notification's attributes.
+func (n *Notification) Map() map[string]interface{} {
+	res := map[string]interface{}{}
+	res["type"] = n.Type
+	for _, attr := range n.Attributes {
+		k := *attr.Name
+		v := *attr.Value
+		switch {
+		case v.BoolValue != nil:
+			res[k] = *v.BoolValue
+		case v.IntValue != nil:
+			res[k] = *v.IntValue
+		case v.UintValue != nil:
+			res[k] = *v.UintValue
+		case v.FloatValue != nil:
+			res[k] = *v.FloatValue
+		case v.StringValue != nil:
+			res[k] = *v.StringValue
+		case v.BlobValue != nil:
+			res[k] = v.BlobValue
+		case v.MessageValue != nil:
+			res[k] = MessageValue{v.MessageValue}
+		case v.FourccValue != nil:
+			res[k] = FourccValue{*v.FourccValue}
+		case v.EntityidValue != nil:
+			res[k] = *v.EntityidValue
+		default:
+			log.Panicf("error: variant(%s) has no value", k)
+		}
+	}
+	return res
+}
+
+func (s *Session) HandleNotifications() {
+	quit := s.ChanForTransition(StateDisconnected)
+	for {
+		select {
+		case notify := <-s.ClientNotifications:
+			s.handleNotification(notify)
+		case <-quit:
+			return
+		}
+	}
+}
+
+func (s *Session) handleNotification(notify *Notification) {
+	log.Printf("received notification (%s): %v\n", notify.Type, notify.Attributes)
+	switch notify.Type {
+	default:
+		if ch, ok := notificationHandlers[notify.Type]; ok {
+			(<-ch)(notify)
+			return
+		}
+		log.Panicf("error: unhandled notification type %s", notify.Type)
+	}
+}
+
+var notificationHandlers = map[string]chan func(*Notification){}
+
+// Will trigger handler once the server is notified with a notification of type
+// ty.
+func (s *Session) OnceNotified(ty string, handle func(n *Notification)) {
+	if ch, ok := notificationHandlers[ty]; ok {
+		ch <- handle
+	} else {
+		ch = make(chan func(*Notification), 1)
+		notificationHandlers[ty] = ch
+		ch <- handle
+	}
+}

--- a/pegasus/account.go
+++ b/pegasus/account.go
@@ -1,7 +1,6 @@
 package pegasus
 
 import (
-	"fmt"
 	"github.com/HearthSim/hs-proto-go/pegasus/shared"
 	"github.com/HearthSim/hs-proto-go/pegasus/util"
 	"github.com/golang/protobuf/proto"
@@ -23,69 +22,69 @@ func (v *Account) Init(sess *Session) {
 	// TODO: fetch the account using the bnet session
 	db.Find(&sess.Account)
 
-	sess.RegisterUtilHandler(0, 201, OnGetAccountInfo)
-	sess.RegisterUtilHandler(0, 205, OnUpdateLogin)
-	sess.RegisterUtilHandler(0, 209, OnCreateDeck)
-	sess.RegisterUtilHandler(0, 210, OnDeleteDeck)
-	sess.RegisterUtilHandler(0, 211, OnRenameDeck)
-	sess.RegisterUtilHandler(0, 214, OnGetDeck)
-	sess.RegisterUtilHandler(0, 222, OnDeckSetData)
-	sess.RegisterUtilHandler(0, 223, OnAckCardSeen)
-	sess.RegisterUtilHandler(0, 225, OnOpenBooster)
-	sess.RegisterUtilHandler(0, 239, OnSetOptions)
-	sess.RegisterUtilHandler(0, 240, OnGetOptions)
-	sess.RegisterUtilHandler(0, 243, OnAckAchieveProgress)
-	sess.RegisterUtilHandler(0, 253, OnGetAchieves)
-	sess.RegisterUtilHandler(0, 267, OnCheckAccountLicenses)
-	sess.RegisterUtilHandler(1, 276, OnCheckGameLicenses)
-	sess.RegisterUtilHandler(0, 281, OnCancelQuest)
-	sess.RegisterUtilHandler(0, 284, OnValidateAchieve)
-	sess.RegisterUtilHandler(0, 291, OnSetCardBack)
-	sess.RegisterUtilHandler(0, 305, OnGetAdventureProgress)
-	sess.RegisterUtilHandler(0, 319, OnSetFavoriteHero)
+	sess.RegisterPacket(util.GetAccountInfo_ID, OnGetAccountInfo)
+	sess.RegisterPacket(util.UpdateLogin_ID, OnUpdateLogin)
+	sess.RegisterPacket(util.CreateDeck_ID, OnCreateDeck)
+	sess.RegisterPacket(util.DeleteDeck_ID, OnDeleteDeck)
+	sess.RegisterPacket(util.RenameDeck_ID, OnRenameDeck)
+	sess.RegisterPacket(util.GetDeck_ID, OnGetDeck)
+	sess.RegisterPacket(util.DeckSetData_ID, OnDeckSetData)
+	sess.RegisterPacket(util.AckCardSeen_ID, OnAckCardSeen)
+	sess.RegisterPacket(util.OpenBooster_ID, OnOpenBooster)
+	sess.RegisterPacket(util.SetOptions_ID, OnSetOptions)
+	sess.RegisterPacket(util.GetOptions_ID, OnGetOptions)
+	sess.RegisterPacket(util.AckAchieveProgress_ID, OnAckAchieveProgress)
+	sess.RegisterPacket(util.GetAchieves_ID, OnGetAchieves)
+	sess.RegisterPacket(util.CheckAccountLicenses_ID, OnCheckAccountLicenses)
+	sess.RegisterPacket(util.CheckGameLicenses_ID, OnCheckGameLicenses)
+	sess.RegisterPacket(util.CancelQuest_ID, OnCancelQuest)
+	sess.RegisterPacket(util.ValidateAchieve_ID, OnValidateAchieve)
+	sess.RegisterPacket(util.SetCardBack_ID, OnSetCardBack)
+	sess.RegisterPacket(util.GetAdventureProgress_ID, OnGetAdventureProgress)
+	sess.RegisterPacket(util.SetFavoriteHero_ID, OnSetFavoriteHero)
 }
 
-func OnAckCardSeen(s *Session, body []byte) ([]byte, error) {
+func OnAckCardSeen(s *Session, body []byte) *Packet {
 	req := util.AckCardSeen{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	log.Printf("FIXME: AckCardSeen = %s", req.String())
-	return nil, nil
+	return nil
 }
 
-func OnCheckAccountLicenses(s *Session, body []byte) ([]byte, error) {
+func OnCheckAccountLicenses(s *Session, body []byte) *Packet {
 	return OnCheckLicenses(true)
 }
 
-func OnCheckGameLicenses(s *Session, body []byte) ([]byte, error) {
+func OnCheckGameLicenses(s *Session, body []byte) *Packet {
 	return OnCheckLicenses(false)
 }
 
-func OnCheckLicenses(accountLevel bool) ([]byte, error) {
+func OnCheckLicenses(accountLevel bool) *Packet {
 	res := util.CheckLicensesResponse{}
 	res.AccountLevel = proto.Bool(accountLevel)
 	res.Success = proto.Bool(true)
-	return EncodeUtilResponse(277, &res)
+	return EncodePacket(util.CheckLicensesResponse_ID, &res)
 }
 
-func OnUpdateLogin(s *Session, body []byte) ([]byte, error) {
+func OnUpdateLogin(s *Session, body []byte) *Packet {
 	req := util.UpdateLogin{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	log.Printf("req = %s", req.String())
 	res := util.UpdateLoginComplete{}
-	return EncodeUtilResponse(307, &res)
+	return EncodePacket(util.UpdateLoginComplete_ID, &res)
 }
 
-func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
+func OnGetAccountInfo(s *Session, body []byte) *Packet {
 	req := util.GetAccountInfo{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	log.Printf("req = %s", req.String())
 	switch req.Request.String() {
@@ -93,7 +92,7 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 		res := util.ProfileProgress{}
 		res.Progress = proto.Int64(6)  // ILLIDAN_COMPLETE
 		res.BestForge = proto.Int32(0) // Arena wins
-		return EncodeUtilResponse(233, &res)
+		return EncodePacket(util.ProfileProgress_ID, &res)
 	case "BOOSTERS":
 		res := util.BoosterList{}
 		classicPacks := s.GetBoosterInfo(1)
@@ -108,11 +107,11 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 		if *tgtPacks.Count > 0 {
 			res.List = append(res.List, tgtPacks)
 		}
-		return EncodeUtilResponse(224, &res)
+		return EncodePacket(util.BoosterList_ID, &res)
 	case "FEATURES":
 		res := util.GuardianVars{}
 		res.ShowUserUI = proto.Int32(1)
-		return EncodeUtilResponse(264, &res)
+		return EncodePacket(util.GuardianVars_ID, &res)
 	case "MEDAL_INFO":
 		res := util.MedalInfo{}
 		res.SeasonWins = proto.Int32(0)
@@ -122,7 +121,7 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 		res.LevelStart = proto.Int32(1)
 		res.LevelEnd = proto.Int32(3)
 		res.CanLose = proto.Bool(false)
-		return EncodeUtilResponse(232, &res)
+		return EncodePacket(util.MedalInfo_ID, &res)
 	case "MEDAL_HISTORY":
 		res := util.MedalHistory{}
 		for i := int32(1); i <= 3; i++ {
@@ -136,10 +135,10 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 			info.LegendRank = proto.Int32(1)
 			res.Medals = append(res.Medals, info)
 		}
-		return EncodeUtilResponse(234, &res)
+		return EncodePacket(util.MedalHistory_ID, &res)
 	case "NOTICES":
 		res := util.ProfileNotices{}
-		return EncodeUtilResponse(212, &res)
+		return EncodePacket(util.ProfileNotices_ID, &res)
 	case "DECK_LIST":
 		res := util.DeckList{}
 		basicDecks := []Deck{}
@@ -156,7 +155,7 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 			info := MakeDeckInfo(&deck)
 			res.Decks = append(res.Decks, info)
 		}
-		return EncodeUtilResponse(202, &res)
+		return EncodePacket(util.DeckList_ID, &res)
 	case "COLLECTION":
 		res := util.Collection{}
 		collectionCards := []CollectionCard{}
@@ -172,26 +171,26 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 			stack1.CardDef = carddef
 			res.Stacks = append(res.Stacks, stack1)
 		}
-		return EncodeUtilResponse(207, &res)
+		return EncodePacket(util.Collection_ID, &res)
 	case "DECK_LIMIT":
 		res := util.ProfileDeckLimit{}
 		res.DeckLimit = proto.Int32(9)
-		return EncodeUtilResponse(231, &res)
+		return EncodePacket(util.ProfileDeckLimit_ID, &res)
 	case "CARD_VALUES":
 		res := util.CardValues{}
 		res.CardNerfIndex = proto.Int32(0)
-		return EncodeUtilResponse(260, &res)
+		return EncodePacket(util.CardValues_ID, &res)
 	case "ARCANE_DUST_BALANCE":
 		res := util.ArcaneDustBalance{}
 		res.Balance = proto.Int64(10000)
-		return EncodeUtilResponse(262, &res)
+		return EncodePacket(util.ArcaneDustBalance_ID, &res)
 	case "GOLD_BALANCE":
 		res := util.GoldBalance{}
 		res.Cap = proto.Int64(999999)
 		res.CapWarning = proto.Int64(2000)
 		res.CappedBalance = proto.Int64(1234)
 		res.BonusBalance = proto.Int64(0)
-		return EncodeUtilResponse(278, &res)
+		return EncodePacket(util.GoldBalance_ID, &res)
 	case "HERO_XP":
 		res := util.HeroXP{}
 		for i := 2; i <= 10; i++ {
@@ -204,10 +203,10 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 			info.MaxXp = proto.Int64(int64(maxXp))
 			res.XpInfos = append(res.XpInfos, info)
 		}
-		return EncodeUtilResponse(283, &res)
+		return EncodePacket(util.HeroXP_ID, &res)
 	case "NOT_SO_MASSIVE_LOGIN":
 		res := util.NotSoMassiveLoginReply{}
-		return EncodeUtilResponse(300, &res)
+		return EncodePacket(util.NotSoMassiveLoginReply_ID, &res)
 	case "REWARD_PROGRESS":
 		res := util.RewardProgress{}
 		nextMonth := time.Date(2015, 8, 1, 7, 0, 0, 0, time.UTC)
@@ -220,18 +219,18 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 		res.MaxHeroLevel = proto.Int32(60)
 		res.NextQuestCancel = PegasusDate(time.Now().UTC())
 		res.EventTimingMod = proto.Float32(0.291667)
-		return EncodeUtilResponse(271, &res)
+		return EncodePacket(util.RewardProgress_ID, &res)
 	case "PVP_QUEUE":
 		res := util.PlayQueue{}
 		queue := shared.PlayQueueInfo{}
 		gametype := shared.BnetGameType_BGT_NORMAL
 		queue.GameType = &gametype
 		res.Queue = &queue
-		return EncodeUtilResponse(286, &res)
+		return EncodePacket(util.PlayQueue_ID, &res)
 
 	case "PLAYER_RECORD":
 		res := util.PlayerRecords{}
-		return EncodeUtilResponse(270, &res)
+		return EncodePacket(util.PlayerRecords_ID, &res)
 	case "CARD_BACKS":
 		res := util.CardBacks{}
 		dbfCardBacks := []DbfCardBack{}
@@ -240,7 +239,7 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 		for _, cardBack := range dbfCardBacks {
 			res.CardBacks = append(res.CardBacks, cardBack.ID)
 		}
-		return EncodeUtilResponse(236, &res)
+		return EncodePacket(util.CardBacks_ID, &res)
 	case "FAVORITE_HEROES":
 		res := util.FavoriteHeroesResponse{}
 		favoriteHeros := []FavoriteHero{}
@@ -256,39 +255,38 @@ func OnGetAccountInfo(s *Session, body []byte) ([]byte, error) {
 			fav.Hero = carddef
 			res.FavoriteHeroes = append(res.FavoriteHeroes, fav)
 		}
-		return EncodeUtilResponse(318, &res)
+		return EncodePacket(util.FavoriteHeroesResponse_ID, &res)
 	case "ACCOUNT_LICENSES":
 		res := util.AccountLicensesInfoResponse{}
-		return EncodeUtilResponse(325, &res)
+		return EncodePacket(util.AccountLicensesInfoResponse_ID, &res)
 	case "BOOSTER_TALLY":
 		res := util.BoosterTallyList{}
-		return EncodeUtilResponse(313, &res)
+		return EncodePacket(util.BoosterTallyList_ID, &res)
 	default:
-
-		return nil, nyi
+		panic(nyi)
 	}
 }
 
-func OnGetAdventureProgress(s *Session, body []byte) ([]byte, error) {
+func OnGetAdventureProgress(s *Session, body []byte) *Packet {
 	res := util.AdventureProgressResponse{}
-	return EncodeUtilResponse(306, &res)
+	return EncodePacket(util.AdventureProgressResponse_ID, &res)
 }
 
-func OnSetOptions(s *Session, body []byte) ([]byte, error) {
+func OnSetOptions(s *Session, body []byte) *Packet {
 	req := util.SetOptions{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	log.Printf("req = %s", req.String())
-	return nil, nil
+	return nil
 }
 
-func OnGetOptions(s *Session, body []byte) ([]byte, error) {
+func OnGetOptions(s *Session, body []byte) *Packet {
 	req := util.GetOptions{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	log.Printf("req = %s", req.String())
 	res := util.ClientOptions{}
@@ -304,14 +302,14 @@ func OnGetOptions(s *Session, body []byte) ([]byte, error) {
 		Index:   proto.Int32(18),
 		AsInt64: proto.Int64(0xB765A8C),
 	})
-	return EncodeUtilResponse(241, &res)
+	return EncodePacket(util.ClientOptions_ID, &res)
 }
 
-func OnGetAchieves(s *Session, body []byte) ([]byte, error) {
+func OnGetAchieves(s *Session, body []byte) *Packet {
 	req := util.GetAchieves{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	res := util.Achieves{}
 	dbfAchieves := []DbfAchieve{}
@@ -330,14 +328,14 @@ func OnGetAchieves(s *Session, body []byte) ([]byte, error) {
 			DateCompleted:   PegasusDate(achieveProgress.DateCompleted),
 		})
 	}
-	return EncodeUtilResponse(252, &res)
+	return EncodePacket(util.Achieves_ID, &res)
 }
 
-func OnSetFavoriteHero(s *Session, body []byte) ([]byte, error) {
+func OnSetFavoriteHero(s *Session, body []byte) *Packet {
 	req := util.SetFavoriteHero{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	// TODO: optionally deny changes and respond accordingly
@@ -352,14 +350,14 @@ func OnSetFavoriteHero(s *Session, body []byte) ([]byte, error) {
 		Success:      proto.Bool(true),
 		FavoriteHero: req.FavoriteHero,
 	}
-	return EncodeUtilResponse(320, &res)
+	return EncodePacket(util.SetFavoriteHeroResponse_ID, &res)
 }
 
-func OnAckAchieveProgress(s *Session, body []byte) ([]byte, error) {
+func OnAckAchieveProgress(s *Session, body []byte) *Packet {
 	req := util.AckAchieveProgress{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	achieve := Achieve{}
@@ -367,26 +365,26 @@ func OnAckAchieveProgress(s *Session, body []byte) ([]byte, error) {
 	achieve.AckProgress = req.GetAckProgress()
 	db.Save(&achieve)
 
-	return nil, nil
+	return nil
 }
 
-func OnValidateAchieve(s *Session, body []byte) ([]byte, error) {
+func OnValidateAchieve(s *Session, body []byte) *Packet {
 	req := util.ValidateAchieve{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	log.Printf("req = %s", req.String())
 	res := util.ValidateAchieveResponse{}
 	res.Achieve = proto.Int32(req.GetAchieve())
-	return EncodeUtilResponse(285, &res)
+	return EncodePacket(util.ValidateAchieveResponse_ID, &res)
 }
 
-func OnCancelQuest(s *Session, body []byte) ([]byte, error) {
+func OnCancelQuest(s *Session, body []byte) *Packet {
 	req := util.CancelQuest{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	// TODO: check if the quest is a daily that can be canceled and if so cancel it.
@@ -400,7 +398,7 @@ func OnCancelQuest(s *Session, body []byte) ([]byte, error) {
 		NextQuestCancel: PegasusDate(time.Now().UTC()),
 	}
 
-	return EncodeUtilResponse(282, &res)
+	return EncodePacket(util.CancelQuestResponse_ID, &res)
 }
 
 func MakeDeckInfo(deck *Deck) *shared.DeckInfo {
@@ -426,11 +424,11 @@ func MakeCardDef(id, premium int32) *shared.CardDef {
 	return res
 }
 
-func OnOpenBooster(s *Session, body []byte) ([]byte, error) {
+func OnOpenBooster(s *Session, body []byte) *Packet {
 	req := util.OpenBooster{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	res := util.BoosterContent{}
@@ -444,7 +442,7 @@ func OnOpenBooster(s *Session, body []byte) ([]byte, error) {
 		}
 		cards := CollectionCard{}
 		if !db.Where("account_id = ? AND card_id = ? AND premium = ?", s.Account.ID, card.CardID, card.Premium).First(&cards).RecordNotFound() {
-			db.Model(&cards).Update("num", cards.Num + 1)
+			db.Model(&cards).Update("num", cards.Num+1)
 		} else {
 			cards.AccountID = s.Account.ID
 			cards.CardID = card.CardID
@@ -456,14 +454,14 @@ func OnOpenBooster(s *Session, body []byte) ([]byte, error) {
 
 	}
 
-	return EncodeUtilResponse(226, &res)
+	return EncodePacket(util.BoosterContent_ID, &res)
 }
 
-func OnGetDeck(s *Session, body []byte) ([]byte, error) {
+func OnGetDeck(s *Session, body []byte) *Packet {
 	req := util.GetDeck{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	id := req.GetDeck()
@@ -472,7 +470,7 @@ func OnGetDeck(s *Session, body []byte) ([]byte, error) {
 
 	// TODO: does this also need to allow brawl/arena decks? what about AI decks?
 	if deck.DeckType != int(shared.DeckType_PRECON_DECK) && deck.AccountID != s.Account.ID {
-		return nil, fmt.Errorf("received OnGetDeck for non-precon deck not owned by account")
+		log.Panicf("received OnGetDeck for non-precon deck not owned by account")
 	}
 
 	deckCards := []DeckCard{}
@@ -492,14 +490,14 @@ func OnGetDeck(s *Session, body []byte) ([]byte, error) {
 		res.Cards = append(res.Cards, cardData)
 	}
 
-	return EncodeUtilResponse(215, &res)
+	return EncodePacket(util.DeckContents_ID, &res)
 }
 
-func OnCreateDeck(s *Session, body []byte) ([]byte, error) {
+func OnCreateDeck(s *Session, body []byte) *Packet {
 	req := util.CreateDeck{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	deck := Deck{
@@ -526,14 +524,14 @@ func OnCreateDeck(s *Session, body []byte) ([]byte, error) {
 	info.HeroOverride = proto.Bool(false)
 	info.Validity = proto.Uint64(1)
 	res.Info = &info
-	return EncodeUtilResponse(217, &res)
+	return EncodePacket(util.DeckCreated_ID, &res)
 }
 
-func OnDeckSetData(s *Session, body []byte) ([]byte, error) {
+func OnDeckSetData(s *Session, body []byte) *Packet {
 	req := util.DeckSetData{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 
 	id := req.GetDeck()
@@ -541,7 +539,7 @@ func OnDeckSetData(s *Session, body []byte) ([]byte, error) {
 	db.First(&deck, id)
 
 	if deck.AccountID != s.Account.ID {
-		return nil, fmt.Errorf("received DeckSetData for deck not owned by account")
+		log.Panicf("received DeckSetData for deck not owned by account")
 	}
 
 	// Clear the deck then re-populate it
@@ -583,28 +581,28 @@ func OnDeckSetData(s *Session, body []byte) ([]byte, error) {
 	res.Result = &result
 	res.MetaData = proto.Int64(id)
 
-	return EncodeUtilResponse(216, &res)
+	return EncodePacket(util.DBAction_ID, &res)
 }
 
-func OnSetCardBack(s *Session, body []byte) ([]byte, error) {
+func OnSetCardBack(s *Session, body []byte) *Packet {
 	req := util.SetCardBack{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	log.Printf("FIXME: SetCardBack stub = %s", req.String())
 	res := util.SetCardBackResponse{}
 	cardback := req.GetCardBack()
 	res.CardBack = &cardback
 	res.Success = proto.Bool(false)
-	return EncodeUtilResponse(292, &res)
+	return EncodePacket(util.SetCardBackResponse_ID, &res)
 }
 
-func OnRenameDeck(s *Session, body []byte) ([]byte, error) {
+func OnRenameDeck(s *Session, body []byte) *Packet {
 	req := util.RenameDeck{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	id := req.GetDeck()
 	deck := Deck{}
@@ -612,7 +610,7 @@ func OnRenameDeck(s *Session, body []byte) ([]byte, error) {
 	db.First(&deck, id)
 
 	if deck.AccountID != s.Account.ID {
-		return nil, fmt.Errorf("received RenameDeck for deck not owned by account")
+		log.Panicf("received RenameDeck for deck not owned by account")
 	}
 
 	deck.Name = name
@@ -622,21 +620,21 @@ func OnRenameDeck(s *Session, body []byte) ([]byte, error) {
 		Deck: proto.Int64(id),
 		Name: proto.String(name),
 	}
-	return EncodeUtilResponse(219, &res)
+	return EncodePacket(util.DeckRenamed_ID, &res)
 }
 
-func OnDeleteDeck(s *Session, body []byte) ([]byte, error) {
+func OnDeleteDeck(s *Session, body []byte) *Packet {
 	req := util.DeleteDeck{}
 	err := proto.Unmarshal(body, &req)
 	if err != nil {
-		return nil, err
+		panic(err)
 	}
 	id := req.GetDeck()
 	deck := Deck{}
 	db.First(&deck, id)
 
 	if deck.AccountID != s.Account.ID {
-		return nil, fmt.Errorf("received DeleteDeck for deck not owned by account")
+		log.Panicf("received DeleteDeck for deck not owned by account")
 	}
 
 	db.Where("deck_id = ?", id).Delete(DeckCard{})
@@ -645,7 +643,7 @@ func OnDeleteDeck(s *Session, body []byte) ([]byte, error) {
 	res := util.DeckDeleted{
 		Deck: proto.Int64(id),
 	}
-	return EncodeUtilResponse(218, &res)
+	return EncodePacket(util.DeckDeleted_ID, &res)
 }
 
 func (s *Session) GetBoosterInfo(kind int32) *shared.BoosterInfo {

--- a/pegasus/server.go
+++ b/pegasus/server.go
@@ -13,6 +13,6 @@ func NewServer(serv *bnet.Server) *Server {
 	return res
 }
 
-func (s *Server) Connect(sess *bnet.Session) bnet.GameSession {
-	return NewSession(s, sess)
+func (s *Server) Connect(sess *bnet.Session) {
+	BindSession(s, sess)
 }

--- a/pegasus/subscription.go
+++ b/pegasus/subscription.go
@@ -15,7 +15,7 @@ type Subscription struct {
 }
 
 func (s *Subscription) Init(sess *Session) {
-	sess.RegisterUtilHandler(0, 314, OnUtilSubscribe)
+	sess.RegisterPacket(util.Subscribe_ID, OnUtilSubscribe)
 }
 
 func (s *Subscription) IsValid() bool {
@@ -27,7 +27,7 @@ func (s *Subscription) IsValid() bool {
 
 // Handle a client's subscribe request.  The response may specify a timeout,
 // after which an active client must resubscribe to renew their session.
-func OnUtilSubscribe(s *Session, body []byte) ([]byte, error) {
+func OnUtilSubscribe(s *Session, body []byte) *Packet {
 	if s.timeout == 0 {
 		s.timeout = 120 * time.Second
 	}
@@ -39,5 +39,5 @@ func OnUtilSubscribe(s *Session, body []byte) ([]byte, error) {
 	res.Route = proto.Uint64(s.route)
 	res.SupportedFeatures = proto.Uint64(3)
 	res.KeepAliveSecs = proto.Uint64(uint64(s.timeout.Seconds()))
-	return EncodeUtilResponse(315, &res)
+	return EncodePacket(util.SubscribeResponse_ID, &res)
 }

--- a/pegasus/util_test.go
+++ b/pegasus/util_test.go
@@ -1,0 +1,26 @@
+package pegasus
+
+import (
+	"github.com/HearthSim/hs-proto-go/pegasus/util"
+	"testing"
+)
+
+func TestUtilRegisterPacket(t *testing.T) {
+	for _, x := range []struct {
+		Enum   interface{}
+		ID     int32
+		System int32
+	}{
+		{util.BuySellCard_ID, 257, 0},
+		{util.GuardianVars_ID, 264, 0},
+		{util.GetPurchaseMethod_ID, 250, 1},
+	} {
+		packetId := packetIDFromProto(x.Enum)
+		if packetId.ID != x.ID {
+			t.Errorf("bad packet id: %d != %d", packetId.ID, x.ID)
+		}
+		if packetId.System != x.System {
+			t.Errorf("bad system id: %d != %d", packetId.System, x.System)
+		}
+	}
+}

--- a/pegasus/version.go
+++ b/pegasus/version.go
@@ -8,11 +8,11 @@ import (
 type Version struct{}
 
 func (v *Version) Init(sess *Session) {
-	sess.RegisterUtilHandler(0, 303, OnAssetsVersion)
+	sess.RegisterPacket(util.GetAssetsVersion_ID, OnAssetsVersion)
 }
 
-func OnAssetsVersion(s *Session, body []byte) ([]byte, error) {
+func OnAssetsVersion(s *Session, body []byte) *Packet {
 	res := util.AssetsVersionResponse{}
-	res.Version = proto.Int32(9166)
-	return EncodeUtilResponse(304, &res)
+	res.Version = proto.Int32(9786)
+	return EncodePacket(util.AssetsVersionResponse_ID, &res)
 }


### PR DESCRIPTION
The notification channel is for all communication between the
bnet server and the game server.

Pegasus Util packet handling has been reworked to use the
PacketID enums in the protos.

A goroutine leak has been stopped, and facilities for any
goroutine to stop itself once the client has disconnected have
been added.

Many error conditions have been reworked to simply panic
instead of returning an error as an argument.  I don't
foresee needing to check the error argument for any of these
cases in the future, as usually the desired behavior is to
disconnect the client in any error condition.

A single test has found its way in to the tree.  Rejoice!