### PR TITLE
Implement FriendNotify client service

### DIFF
--- a/bnet/server.go
+++ b/bnet/server.go
@@ -68,6 +68,7 @@ func NewServer() *Server {
 	s.registerService(ChallengeNotifyServiceBinder{})
 	s.registerService(NotificationListenerServiceBinder{})
 	s.registerService(ChannelInvitationNotifyServiceBinder{})
+	s.registerService(FriendsNotifyServiceBinder{})
 
 	return s
 }


### PR DESCRIPTION
Needed for notifying client that Friend Invitation was accepted/denied.

Implementation of client notification (will pull request this commit later as it is dependent on https://github.com/HearthSim/stove/pull/37 and may need some polishing): https://github.com/quoing/stove/commit/cd45cb98c5477c557dbcdb1a32ab5e83f86f9594#diff-5a5e5843440f049150fa1887408b52a0R191

